### PR TITLE
fig image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine AS go-build
 
 # Build /go/bin/obfs4proxy & /go/bin/meek-server
 RUN apk --no-cache add --update git \
- && go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy \
+ && go get -v gitlab.com/yawning/obfs4.git/obfs4proxy \
  && go get -v git.torproject.org/pluggable-transports/meek.git/meek-server \
  && cp -rv /go/bin /usr/local/
 


### PR DESCRIPTION
obfs4 repo has moved to gitlab.com/yawning/obfs4.git

the build was failing with this error before:

> $ docker build .
> Sending build context to Docker daemon    150kB
> Step 1/18 : FROM golang:alpine AS go-build
>  ---> 35cd8c8897b1
> Step 2/18 : RUN apk --no-cache add --update git  && go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy  && go get -v git.torproject.org/pluggable-transports/meek.git/meek-server  && cp -rv /go/bin /usr/local/
>  ---> Running in e6ab2ba7044f
> fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
> fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
> (1/6) Installing brotli-libs (1.0.9-r5)
> (2/6) Installing nghttp2-libs (1.43.0-r0)
> (3/6) Installing libcurl (7.79.1-r0)
> (4/6) Installing expat (2.4.1-r0)
> (5/6) Installing pcre2 (10.36-r0)
> (6/6) Installing git (2.32.0-r0)
> Executing busybox-1.33.1-r3.trigger
> OK: 19 MiB in 21 packages
> go: downloading git.torproject.org/pluggable-transports/obfs4.git v0.0.0-20201207231651-40245c4a1cf2
> go get: git.torproject.org/pluggable-transports/obfs4.git@v0.0.0-20201207231651-40245c4a1cf2: parsing go.mod:
>         module declares its path as: gitlab.com/yawning/obfs4.git
>                 but was required as: git.torproject.org/pluggable-transports/obfs4.git
> The command '/bin/sh -c apk --no-cache add --update git  && go get -v git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy  && go get -v git.torproject.org/pluggable-transports/meek.git/meek-server  && cp -rv /go/bin /usr/local/' returned a non-zero code: 1